### PR TITLE
For Neon dependencies, use Region-local S3 bucket when running from EC2 instance

### DIFF
--- a/Top.cmake
+++ b/Top.cmake
@@ -15,12 +15,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 elseif(EXISTS $ENV{VIRTUAL_ENV})
   message("Installing python dependencies.")
   execute_process(
-    COMMAND ${CMAKE_SOURCE_DIR}/.pyenv/bin/pip install -r ${CMAKE_SOURCE_DIR}/pre_requirements.txt --no-index --find-links http://s3-us-west-1.amazonaws.com/neon-dependencies/index.html
+    COMMAND ${CMAKE_SOURCE_DIR}/.pyenv/bin/pip install -r ${CMAKE_SOURCE_DIR}/pre_requirements.txt --no-index --find-links $ENV{NEON_DEPS_URL}
     RESULT_VARIABLE FAILED_PY_INSTALL
     )
   if(NOT FAILED_PY_INSTALL)
     execute_process(
-      COMMAND ${CMAKE_SOURCE_DIR}/.pyenv/bin/pip install -r ${CMAKE_SOURCE_DIR}/requirements.txt --no-index --find-links http://s3-us-west-1.amazonaws.com/neon-dependencies/index.html
+      COMMAND ${CMAKE_SOURCE_DIR}/.pyenv/bin/pip install -r ${CMAKE_SOURCE_DIR}/requirements.txt --no-index --find-links $ENV{NEON_DEPS_URL}
     
       RESULT_VARIABLE FAILED_PY_INSTALL
       )

--- a/neon_repos.sh
+++ b/neon_repos.sh
@@ -1,0 +1,23 @@
+# Determine if running from EC2 instance, if so, use a Region-local S3 bucket
+# for Neon dependencies.
+#
+# To use: source neon_deps.sh
+#
+
+if AZ=$(curl -s 169.254.169.254/latest/meta-data/placement/availability-zone) ; then
+  REGION=${AZ%?}
+  export AZ REGION
+fi
+
+PROTO=https
+
+case $REGION in 
+  ( us-east-1 )
+    export NEON_DEPS_URL="${PROTO}://s3.amazonaws.com/neon-dependencies-us-east-1/index.html"
+  ;;
+  ( * ) # use default in AWS Region: US-West-1
+    export NEON_DEPS_URL="${PROTO}://s3-us-west-1.amazonaws.com/neon-dependencies/index.html"
+  ;;
+esac
+
+echo "Pip index url: ${NEON_DEPS_URL}"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,6 +10,8 @@
 CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${CURDIR}
 
+. neon_repos.sh
+
 if [ $# -eq 0 ] ; then
     BUILDTYPE=Debug
 else


### PR DESCRIPTION
This adds the capability to detect the local AWS Region, if the build is running from an EC2 instance, and use the Region-local S3 bucket. 

The index url was switched to HTTPS instead of HTTP.
#### S3 Buckets

The current buckets supported:

| Region | Bucket |
| --- | --- |
| default | `neon-dependencies` (the master bucket, located in US-West-1) |
| US-East-1 | `neon-dependencies-us-east-1` |
#### S3 Cross Region Replication

`neon-dependencies-us-east-1` uses S3 Cross Region replication to stay in-sync with the master bucket.
